### PR TITLE
feat: add minimalist spreadsheet editor

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,103 +1,63 @@
-import Image from "next/image";
+'use client';
+
+import { useState } from 'react';
+import MetadataForm from '../components/MetadataForm';
+import Spreadsheet from '../components/Spreadsheet';
+import PreviewSheet from '../components/PreviewSheet';
+import type { Metadata, RowData } from '../components/types';
 
 export default function Home() {
-  return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+  const [metadata, setMetadata] = useState<Metadata>({
+    order: '',
+    dueDate: '',
+    customer: '',
+    contact: '',
+    note: '',
+  });
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
+  const [rows, setRows] = useState<RowData[]>([
+    {
+      image: '',
+      drawing: '',
+      spec: '',
+      material: '',
+      quantity: '',
+      machining: '',
+      process: '',
+      note: '',
+      unitPrice: '',
+      totalPrice: '',
+      purchase: false,
+    },
+  ]);
+
+  const [preview, setPreview] = useState<string | null>(null);
+
+  return (
+    <main className="min-h-screen bg-gray-100 p-8 font-sans">
+      <div className="max-w-full mx-auto space-y-6">
+        <MetadataForm metadata={metadata} onChange={setMetadata} />
+        <Spreadsheet rows={rows} onChange={setRows} />
+        <div className="flex gap-4 justify-center mt-6">
+          {['报价单', '生产单', '送货单', '采购单'].map((ch) => (
+            <button
+              key={ch}
+              onClick={() => setPreview(ch)}
+              className="px-4 py-2 bg-white rounded-lg shadow hover:bg-gray-50"
+            >
+              {ch}
+            </button>
+          ))}
         </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+      </div>
+      {preview && (
+        <PreviewSheet
+          metadata={metadata}
+          rows={rows}
+          channel={preview}
+          onClose={() => setPreview(null)}
+        />
+      )}
+    </main>
   );
 }

--- a/components/MetadataForm.tsx
+++ b/components/MetadataForm.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import type { Metadata } from "./types";
+
+interface Props {
+  metadata: Metadata;
+  onChange: (meta: Metadata) => void;
+}
+
+export default function MetadataForm({ metadata, onChange }: Props) {
+  const handle = (field: keyof Metadata) => (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    onChange({ ...metadata, [field]: e.target.value });
+  };
+
+  return (
+    <div className="grid grid-cols-5 gap-4 p-4 bg-white rounded-xl shadow mb-6">
+      <input
+        className="border-b border-gray-300 focus:outline-none focus:border-black px-2 py-1"
+        placeholder="销售单号"
+        value={metadata.order}
+        onChange={handle("order")}
+      />
+      <input
+        className="border-b border-gray-300 focus:outline-none focus:border-black px-2 py-1"
+        placeholder="交期"
+        value={metadata.dueDate}
+        onChange={handle("dueDate")}
+      />
+      <input
+        className="border-b border-gray-300 focus:outline-none focus:border-black px-2 py-1"
+        placeholder="客户名称"
+        value={metadata.customer}
+        onChange={handle("customer")}
+      />
+      <input
+        className="border-b border-gray-300 focus:outline-none focus:border-black px-2 py-1"
+        placeholder="联系人"
+        value={metadata.contact}
+        onChange={handle("contact")}
+      />
+      <input
+        className="border-b border-gray-300 focus:outline-none focus:border-black px-2 py-1"
+        placeholder="备注"
+        value={metadata.note}
+        onChange={handle("note")}
+      />
+    </div>
+  );
+}

--- a/components/PreviewSheet.tsx
+++ b/components/PreviewSheet.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import type { Metadata, RowData } from "./types";
+
+type Column = { key: keyof RowData; label: string; type?: "checkbox" };
+
+const columns: Column[] = [
+  { key: "image", label: "零件图片" },
+  { key: "drawing", label: "图号" },
+  { key: "spec", label: "规格" },
+  { key: "material", label: "材料" },
+  { key: "quantity", label: "数量" },
+  { key: "machining", label: "加工方式" },
+  { key: "process", label: "工艺要求" },
+  { key: "note", label: "备注" },
+  { key: "unitPrice", label: "单价" },
+  { key: "totalPrice", label: "总价" },
+  { key: "purchase", label: "采购", type: "checkbox" },
+];
+
+const channelColumns: Record<string, Column[]> = {
+  报价单: columns,
+  生产单: columns.filter((c) => c.key !== "unitPrice" && c.key !== "totalPrice"),
+  送货单: columns.filter((c) => c.key !== "unitPrice"),
+  采购单: columns.filter((c) =>
+    ["image", "drawing", "spec", "material", "quantity", "purchase"].includes(
+      c.key
+    )
+  ),
+};
+
+interface Props {
+  metadata: Metadata;
+  rows: RowData[];
+  channel: string;
+  onClose: () => void;
+}
+
+export default function PreviewSheet({ metadata, rows, channel, onClose }: Props) {
+  const cols = channelColumns[channel] || columns;
+  return (
+    <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
+      <div className="relative bg-white rounded-xl shadow-xl w-11/12 h-5/6 p-8 overflow-auto">
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-gray-500 hover:text-black"
+        >
+          ✕
+        </button>
+        <h2 className="text-center text-xl font-semibold mb-6">{channel}</h2>
+        <div className="grid grid-cols-5 gap-4 text-sm mb-6">
+          <div>销售单号: {metadata.order}</div>
+          <div>交期: {metadata.dueDate}</div>
+          <div>客户名称: {metadata.customer}</div>
+          <div>联系人: {metadata.contact}</div>
+          <div>备注: {metadata.note}</div>
+        </div>
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>
+              {cols.map((col) => (
+                <th
+                  key={col.key}
+                  className="border-b border-gray-200 px-2 py-1 text-left font-medium"
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => (
+              <tr key={i} className="odd:bg-gray-50">
+                {cols.map((col) => (
+                  <td key={col.key} className="border-b border-gray-100 px-2 py-1">
+                    {col.type === "checkbox" ? (
+                      row[col.key] ? "✔" : ""
+                    ) : (
+                      <div
+                        dangerouslySetInnerHTML={{
+                          __html: row[col.key] as string,
+                        }}
+                      />
+                    )}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="mt-4 text-right">
+          <button
+            onClick={() => window.print()}
+            className="px-4 py-2 bg-black text-white rounded hover:bg-gray-800"
+          >
+            打印
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/Spreadsheet.tsx
+++ b/components/Spreadsheet.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import type { RowData } from "./types";
+
+type Column = { key: keyof RowData; label: string; type?: "checkbox" };
+
+const columns: Column[] = [
+  { key: "image", label: "零件图片" },
+  { key: "drawing", label: "图号" },
+  { key: "spec", label: "规格" },
+  { key: "material", label: "材料" },
+  { key: "quantity", label: "数量" },
+  { key: "machining", label: "加工方式" },
+  { key: "process", label: "工艺要求" },
+  { key: "note", label: "备注" },
+  { key: "unitPrice", label: "单价" },
+  { key: "totalPrice", label: "总价" },
+  { key: "purchase", label: "采购", type: "checkbox" },
+];
+
+interface Props {
+  rows: RowData[];
+  onChange: (rows: RowData[]) => void;
+}
+
+export default function Spreadsheet({ rows, onChange }: Props) {
+  const handleInput = (
+    rowIndex: number,
+    key: keyof RowData,
+    value: string | boolean
+  ) => {
+    const updated = rows.map((r, i) =>
+      i === rowIndex ? { ...r, [key]: value } : r
+    );
+    onChange(updated);
+  };
+
+  const handlePaste = (
+    rowIndex: number,
+    key: keyof RowData,
+    e: React.ClipboardEvent<HTMLDivElement>
+  ) => {
+    const file = e.clipboardData.files[0];
+    if (file && file.type.startsWith("image/")) {
+      e.preventDefault();
+      const reader = new FileReader();
+      reader.onload = (evt) => {
+        handleInput(rowIndex, key, `<img src="${evt.target?.result}" class="max-h-16 object-contain" />`);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const addRow = () => {
+    onChange([
+      ...rows,
+      {
+        image: "",
+        drawing: "",
+        spec: "",
+        material: "",
+        quantity: "",
+        machining: "",
+        process: "",
+        note: "",
+        unitPrice: "",
+        totalPrice: "",
+        purchase: false,
+      },
+    ]);
+  };
+
+  return (
+    <div className="bg-white rounded-xl shadow p-4 overflow-auto">
+      <table className="w-full border-collapse text-sm">
+        <thead>
+          <tr>
+            {columns.map((col) => (
+              <th
+                key={col.key}
+                className="border-b border-gray-200 px-2 py-1 text-left font-medium"
+              >
+                {col.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={i} className="odd:bg-gray-50">
+              {columns.map((col) => (
+                <td key={col.key} className="border-b border-gray-100 px-2 py-1">
+                  {col.type === "checkbox" ? (
+                    <input
+                      type="checkbox"
+                      checked={row[col.key] as boolean}
+                      onChange={(e) => handleInput(i, col.key, e.target.checked)}
+                    />
+                  ) : (
+                    <div
+                      className="min-h-[40px] outline-none focus:ring-1 focus:ring-black/40 p-1"
+                      contentEditable
+                      suppressContentEditableWarning
+                      onInput={(e) =>
+                        handleInput(i, col.key, e.currentTarget.innerHTML)
+                      }
+                      onPaste={(e) => handlePaste(i, col.key, e)}
+                      dangerouslySetInnerHTML={{
+                        __html: row[col.key] as string,
+                      }}
+                    />
+                  )}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button
+        onClick={addRow}
+        className="mt-4 px-3 py-1 border border-gray-300 rounded hover:bg-gray-100"
+      >
+        + 添加行
+      </button>
+    </div>
+  );
+}

--- a/components/types.ts
+++ b/components/types.ts
@@ -1,0 +1,21 @@
+export interface Metadata {
+  order: string;
+  dueDate: string;
+  customer: string;
+  contact: string;
+  note: string;
+}
+
+export interface RowData {
+  image: string;
+  drawing: string;
+  spec: string;
+  material: string;
+  quantity: string;
+  machining: string;
+  process: string;
+  note: string;
+  unitPrice: string;
+  totalPrice: string;
+  purchase: boolean;
+}


### PR DESCRIPTION
## Summary
- add global metadata form and editable spreadsheet
- generate printable previews for 报价单、生产单、送货单、采购单

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_689f0a854f14832d8d2721d61c7afe1b